### PR TITLE
Add Card component to genres page to display book information

### DIFF
--- a/apps/frontend/src/routes/genres/[slug]/+page.svelte
+++ b/apps/frontend/src/routes/genres/[slug]/+page.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import Card from "../../../pageComponents/index/Card.svelte";
+
   export let data;
   console.log(data.books.length);
 </script>
@@ -8,7 +10,11 @@
 
   <div>
     {#each data.books as book}
-      <p>{book.title}</p>
+      <Card
+        title={book.title}
+        description={book.description}
+        link={`/books/${book.title}`}
+      />
     {/each}
   </div>
 {:else}


### PR DESCRIPTION
The Card component is imported and used in the genres/[slug]/+page.svelte file to display book information. Each book in the data.books array is rendered as a Card component with the book's title, description, and a link to the book's page. This improves the user experience by providing a visually appealing and organized way to display book information on the genres page.
