### PR TITLE
feat(book.ts): add default values for _id and comments properties in the book store

### DIFF
--- a/apps/frontend/src/store/book.ts
+++ b/apps/frontend/src/store/book.ts
@@ -2,6 +2,7 @@ import { writable } from "svelte/store";
 import type { Book } from "../types/Book";
 
 export const book = writable<Book>({
+  _id: 0,
   links: [],
   author: "",
   title: "",
@@ -10,5 +11,6 @@ export const book = writable<Book>({
   upvotes: 0,
   postedDate: new Date(),
   genre: "",
+  comments: [],
   status: "Pending",
 });


### PR DESCRIPTION
The changes were made to the `book.ts` file in the `store` directory of the `frontend` app. The default values for the `_id` and `comments` properties were added to the `book` store. This ensures that when a new book is created, it will have a default value of 0 for `_id` and an empty array for `comments`.
